### PR TITLE
Updates image references to point at paketo-buildpacks

### DIFF
--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -42,13 +42,13 @@ function tools::install() {
 
 function images::pull() {
     util::print::title "Pulling build image..."
-    docker pull "${CNB_BUILD_IMAGE:=cloudfoundry/build:full-cnb}"
+    docker pull "${CNB_BUILD_IMAGE:=gcr.io/paketo-buildpacks/build:full-cnb-cf}"
 
     util::print::title "Pulling run image..."
-    docker pull "${CNB_RUN_IMAGE:=cloudfoundry/run:full-cnb}"
+    docker pull "${CNB_RUN_IMAGE:=gcr.io/paketo-buildpacks/run:full-cnb-cf}"
 
     util::print::title "Pulling cflinuxfs3 builder image..."
-    docker pull "${CNB_BUILDER_IMAGE:=cloudfoundry/cnb:cflinuxfs3}"
+    docker pull "${CNB_BUILDER_IMAGE:=gcr.io/paketo-buildpacks/builder:cflinuxfs3}"
 
     export CNB_BUILD_IMAGE
     export CNB_RUN_IMAGE


### PR DESCRIPTION
This should allow [this failing job](https://buildpacks.ci.cf-app.com/teams/feature-eng/pipelines/nodejs-compat-cnb/jobs/integration-tests/builds/6) to pass.